### PR TITLE
Minor fixes

### DIFF
--- a/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
+++ b/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
@@ -24,7 +24,7 @@ A [PDF](https://github.com/carpentries/public-survey-info/blob/master/documents/
 This analysis includes 476 observations. Not all respondents answered each of the 26 questions.
 
 ```{r include=FALSE}
-data <- readr::read_csv("https://raw.githubusercontent.com/kariljordan/public-survey-info/master/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-data-public.csv")
+data <- readr::read_csv("https://raw.githubusercontent.com/carpentries/assessment/master/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-data-public.csv")
 ```
 
 ```{r include=FALSE}

--- a/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
+++ b/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
@@ -537,7 +537,7 @@ data %>%
              fill = key)) +
     geom_bar(stat = "identity", 
              position = "dodge") +
-    geom_text(aes(label=n), size= 4) +
+    geom_text(aes(label=n), size= 4, position = position_dodge(width = 1)) +
     scale_x_discrete(labels = function(x) lapply(strwrap(x,
                                                          width = 10,
                                                          simplify = FALSE),

--- a/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
+++ b/public-survey-info/documents/reports/Carpentry-Reports/Long-Term-Feedback-Survey-Report/2017-04-17-carpentry-long-term-assessment-survey-report.rmd
@@ -8,12 +8,6 @@ opts_chunk$set(echo = FALSE,
                message = FALSE,
                warning = FALSE)
 library(tidyverse)
-library(ggplot2)
-library(dplyr)
-library(tidyr)
-library(readr)
-library(purrr)
-library(tibble)
 library(DBI)
 library(ggmap)
 library(likert)


### PR DESCRIPTION
* Removed redundant library calls since `library("tidyverse")` loads them all together.
* Update csv URL to reflect new repo location and structure
* Fix horizontal dodge for text labels of grouped bar plot